### PR TITLE
fix: if on Windows call npm.cmd instead of npm

### DIFF
--- a/modules/check-version.js
+++ b/modules/check-version.js
@@ -6,7 +6,12 @@ module.exports = () => {
   const pjson = JSON.parse(readFileSync(path.join(__dirname, '..', 'package.json'), 'utf8'))
   const pkgName = pjson.name
   const localVer = pjson.version
-  const npmData = JSON.parse(spawnSync('npm', ['view', pkgName, '--json']).stdout.toString())
+  let npmData
+  if (process.platform === 'win32') {
+    npmData = JSON.parse(spawnSync('npm.cmd', ['view', pkgName, '--json']).stdout.toString())
+  } else {
+    npmData = JSON.parse(spawnSync('npm', ['view', pkgName, '--json']).stdout.toString())
+  }
   const remoteVer = npmData.version
   if (checkSum(localVer) < checkSum(remoteVer)) {
     console.log(`WARNING: your local version of ${pkgName} is ${localVer} while the latest available version on npm is ${remoteVer}. Please consider updating your client as you may be using an outdated CSV mapping...`)


### PR DESCRIPTION
**Changes description**
Fix an issue where checkVersion() would run into an error on Windows due to a faulty command that throws an error wich wasn't handled

**Updated features**
- check-version: command calls npm.cmd instead of npm on Windows systems
Tag any people who should have a look to this PR.